### PR TITLE
Default Chorus to be true for "Has been notified of rights"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.4.0 (July 14th, 2020)
+
+- Updates Chorus to default to default "yes" to the request of "Has been notified of rights" clause of the CCPA
+
 ## 1.3.1 (July 2nd, 2020)
 
 - Point to Babel-processed code in the `/dist` folder

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-privacy-compliance",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "Vox Media's library for implementing data privacy frameworks",
   "main": "dist/data-privacy-compliance.js",
   "license": "Apache-2.0",

--- a/src/frameworks/ccpa_on_chorus.js
+++ b/src/frameworks/ccpa_on_chorus.js
@@ -19,8 +19,8 @@ class CcpaOnChorus extends FrameworkBase {
   }
 
   hasBeenNotifiedOfRights() {
-    // see https://github.com/voxmedia/sbn/commit/ce74ab006c89afe799afffa2a31137454d9e5bb3
-    return Cookie.hasCookie('_chorus_ccpa_consent');
+    // see https://voxmedia.slack.com/archives/CPJDM3CCU/p1594741208106400
+    return true;
   }
 
   isLSPACoveredTransaction() {

--- a/test/ccpa_on_chorus.spec.js
+++ b/test/ccpa_on_chorus.spec.js
@@ -28,8 +28,8 @@ describe('CCPA for Chorus Support', () => {
       expect(PrivacyCompliance.canUsePersonalInformationForTargeting()).toBeTruthy();
     });
 
-    it('should default to not notified of rights', () => {
-      expect(PrivacyCompliance.hasBeenNotifiedOfRights()).toBeFalsy();
+    it('should default to not notified of rights on chorus', () => {
+      expect(PrivacyCompliance.hasBeenNotifiedOfRights()).toBeTruthy();
     });
   });
 
@@ -45,11 +45,6 @@ describe('CCPA for Chorus Support', () => {
     it('should restrict personal info targeting, when opt out of sale cookie is set', () => {
       document.cookie = '_chorus_ccpa_consent_donotsell=abcd1234';
       expect(PrivacyCompliance.canUsePersonalInformationForTargeting()).toBeFalsy();
-    });
-
-    it('should restrict personal info targeting, when opt out of sale cookie is set', () => {
-      document.cookie = '_chorus_ccpa_consent=abcd1234';
-      expect(PrivacyCompliance.hasBeenNotifiedOfRights()).toBeTruthy();
     });
   });
 });


### PR DESCRIPTION
After talking with legal council and the chorus team, it is no longer necessary to read the cookie values for the "Has been notified of rights" setting. 

Instead we now default this value to true.