### PR TITLE
Updates canUsePersonalInformationForTargeting check to look for new Chorus Preferences do not sell cookie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.5.0 (November 10, 2021)
+
+- Updates canUsePersonalInformationForTargeting check to look for new Chorus Preferences do not sell cookie
+
 ## 1.4.0 (July 14th, 2020)
 
 - Updates Chorus to default to default "yes" to the request of "Has been notified of rights" clause of the CCPA

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-privacy-compliance",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Vox Media's library for implementing data privacy frameworks",
   "main": "dist/data-privacy-compliance.js",
   "license": "Apache-2.0",

--- a/src/frameworks/ccpa_on_chorus.js
+++ b/src/frameworks/ccpa_on_chorus.js
@@ -22,14 +22,10 @@ class CcpaOnChorus extends FrameworkBase {
     if (!Cookie.hasCookie('chorus_preferences')) return false;
     try {
       const chorusPreferences = JSON.parse(decodeURIComponent(Cookie.getCookie('chorus_preferences')));
-      if (typeof chorusPreferences.privacy === 'object') {
-        return chorusPreferences.privacy.doNotSell;
-      } else {
-        return true;
-      }
+      return Boolean(chorusPreferences.privacy && chorusPreferences.privacy.doNotSell);
     } catch (e) {
       console.error(`There was an error obtaining Chorus Preferences do not sell cookie: ${e}`);
-      return true;
+      return false;
     }
   }
 

--- a/src/frameworks/ccpa_on_chorus.js
+++ b/src/frameworks/ccpa_on_chorus.js
@@ -15,7 +15,18 @@ class CcpaOnChorus extends FrameworkBase {
   }
 
   canUsePersonalInformationForTargeting() {
-    return !Cookie.hasCookie('_chorus_ccpa_consent_donotsell');
+    return !Cookie.hasCookie('_chorus_ccpa_consent_donotsell') && !this.chorusDoNotSellPreference();
+  }
+
+  chorusDoNotSellPreference() {
+    if (!Cookie.hasCookie('chorus_preferences')) return false;
+    try {
+      const chorusPreferences = JSON.parse(decodeURIComponent(Cookie.getCookie('chorus_preferences')));
+      return chorusPreferences.privacy.doNotSell;
+    } catch (e) {
+      console.error(`There was an error obtaining Chorus Preferences do not sell cookie: ${e}`);
+      return false;
+    }
   }
 
   hasBeenNotifiedOfRights() {

--- a/src/frameworks/ccpa_on_chorus.js
+++ b/src/frameworks/ccpa_on_chorus.js
@@ -22,7 +22,11 @@ class CcpaOnChorus extends FrameworkBase {
     if (!Cookie.hasCookie('chorus_preferences')) return false;
     try {
       const chorusPreferences = JSON.parse(decodeURIComponent(Cookie.getCookie('chorus_preferences')));
-      return chorusPreferences.privacy.doNotSell;
+      if (typeof chorusPreferences.privacy === 'object') {
+        return chorusPreferences.privacy.doNotSell;
+      } else {
+        return false;
+      }
     } catch (e) {
       console.error(`There was an error obtaining Chorus Preferences do not sell cookie: ${e}`);
       return false;

--- a/src/frameworks/ccpa_on_chorus.js
+++ b/src/frameworks/ccpa_on_chorus.js
@@ -25,11 +25,11 @@ class CcpaOnChorus extends FrameworkBase {
       if (typeof chorusPreferences.privacy === 'object') {
         return chorusPreferences.privacy.doNotSell;
       } else {
-        return false;
+        return true;
       }
     } catch (e) {
       console.error(`There was an error obtaining Chorus Preferences do not sell cookie: ${e}`);
-      return false;
+      return true;
     }
   }
 

--- a/test/ccpa_on_chorus.spec.js
+++ b/test/ccpa_on_chorus.spec.js
@@ -33,13 +33,18 @@ describe('CCPA for Chorus Support', () => {
     });
   });
 
-  describe('it should repsect Chorus cookies', () => {
+  describe('it should respect Chorus cookies', () => {
     beforeEach(() => {
       window.Chorus = { fakeData: 'fine' };
     });
 
     afterEach(() => {
-      window.cookie = '';
+      document.cookie = '';
+    });
+
+    it('should restrict personal info targeting, when the chorus preferences do not sell cookie is set', () => {
+      document.cookie = 'chorus_preferences={"v":1,"privacy":{"cookies":"essential","doNotSell":true}}';
+      expect(PrivacyCompliance.canUsePersonalInformationForTargeting()).toBeFalsy();
     });
 
     it('should restrict personal info targeting, when opt out of sale cookie is set', () => {


### PR DESCRIPTION
### Purpose
Chorus will be rolling out the use of new Chorus Preferences soon that will include updated privacy information based on user preferences. We will have a banner that asks whether a user wants all, essential, or no cookies. Once a user makes their selection, the `chorus_preferences` cookie will be updated to include both the cookie selection as well as a boolean `doNotSell` property. 

Nicole Zhu has asked us to include this new `doNotSell` property within the check for the  `canUsePersonalInformationForTargeting` method. For the time being we will also be keeping the check for the existing `_chorus_ccpa_consent_donotsell` cookie which will eventually be phased out.

### Gif
<img src="https://media.giphy.com/media/p8fgbnLzWWtEI/giphy.gif">